### PR TITLE
fix: Get text from the Clipboard now works correctly for Unicode texts

### DIFF
--- a/src/Commands/ClipboardCommand.cs
+++ b/src/Commands/ClipboardCommand.cs
@@ -49,7 +49,7 @@ namespace FileDiffer
                     Encoding encoding = GetEncoding(right);
 
                     var left = Path.ChangeExtension(Path.GetTempFileName(), Path.GetExtension(right));
-                    File.WriteAllText(left, Clipboard.GetText(TextDataFormat.Text), encoding);
+                    File.WriteAllText(left, Clipboard.GetText(TextDataFormat.UnicodeText), encoding);
 
                     SelectedFilesCommand.Diff(left, right);
                     File.Delete(left);
@@ -75,7 +75,7 @@ namespace FileDiffer
 
         private static bool CanFilesBeCompared()
         {
-            return !string.IsNullOrWhiteSpace(Clipboard.GetText(TextDataFormat.Text));
+            return !string.IsNullOrWhiteSpace(Clipboard.GetText(TextDataFormat.UnicodeText));
         }
     }
 }

--- a/src/Commands/DocumentClipboardCommand.cs
+++ b/src/Commands/DocumentClipboardCommand.cs
@@ -50,7 +50,7 @@ namespace FileDiffer
             {
                 var ext = Path.GetExtension(_dte.ActiveDocument.FullName);
 
-                var left = CreateTempFileFromClipboard(ext, Clipboard.GetText(TextDataFormat.Text));
+                var left = CreateTempFileFromClipboard(ext, Clipboard.GetText(TextDataFormat.UnicodeText));
                 var right = _dte.ActiveDocument.FullName;
 
                 SelectedFilesCommand.Diff(left, right);
@@ -67,7 +67,7 @@ namespace FileDiffer
 
         private static bool CanFilesBeCompared()
         {
-            return !string.IsNullOrWhiteSpace(Clipboard.GetText(TextDataFormat.Text));
+            return !string.IsNullOrWhiteSpace(Clipboard.GetText(TextDataFormat.UnicodeText));
         }
     }
 }

--- a/src/Commands/SelectionClipboardCommand.cs
+++ b/src/Commands/SelectionClipboardCommand.cs
@@ -53,7 +53,7 @@ namespace FileDiffer
                 var selection = (TextSelection)_dte.ActiveDocument.Selection;
 
                 var left = CreateTempFileFromClipboard(ext, selection.Text);
-                var right = CreateTempFileFromClipboard(ext, Clipboard.GetText(TextDataFormat.Text));
+                var right = CreateTempFileFromClipboard(ext, Clipboard.GetText(TextDataFormat.UnicodeText));
 
                 SelectedFilesCommand.Diff(left, right);
                 File.Delete(left);
@@ -70,7 +70,7 @@ namespace FileDiffer
 
         private static bool CanFilesBeCompared()
         {
-            return !string.IsNullOrWhiteSpace(Clipboard.GetText(TextDataFormat.Text));
+            return !string.IsNullOrWhiteSpace(Clipboard.GetText(TextDataFormat.UnicodeText));
         }
     }
 }


### PR DESCRIPTION
For Unicode texts (such as those containing Persian letters) a `?` character is read from the Clipboard instead of the correct character. Using `Clipboard.GetText(TextDataFormat.UnicodeText)` the bug will be fixed.

Here's a sample shows what happen for Persian letters:

![{EF66ED32-DD73-40DC-B7BF-A89D165390FE}](https://github.com/user-attachments/assets/bd94f2c2-79a1-4d6e-9282-d5bebb05900f)
